### PR TITLE
strava_oauth2 returns inline

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,6 +23,7 @@ pyarrow = "*"
 urllib3 = "*"
 certifi = "*"
 loguru = "*"
+requests = "*"
 
 [requires]
 python_version = "3.6"


### PR DESCRIPTION
The access token from Strava is currently returned in the browser, not inline in your Python code.
I had an idea on how to return the access token inline in your Python code like this:
```python
from stravaio import strava_oauth2
token = strava_oauth2(client_id=STRAVA_CLIENT_ID, client_secret=STRAVA_CLIENT_SECRET)
```
This PR includes the code that adds this feature. The code is a bit wonky (e.g. too much use of low level `socket` and `urllib` thingies), but I hope you are open to accepting it!

By the way: The returned token object is the full Strava response for the OAuth2 token exchange, which includes not only the access token, but also the refresh token among other things. I think it might make sense to e.g. only return access and refresh token.