### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Both `STRAVA_CLIENT_ID` and `STRAVA_CLIENT_SECRET` are optional arguments if the
 
 Another way is to head to the [strava-oauth](https://github.com/sladkovm/strava-oauth) library for help. There you will find a link to the public webserver that can be used for completing the Strava authorizatio flow.
 
-When the token is fetched it is handy to store it as an environment variable. Otherwise it should be passed explicitely to the StravaIO constructor.
+When the token is fetched it is handy to store it as an environment variable. Otherwise it should be passed explicitly to the StravaIO constructor.
 
 ```bash
 export STRAVA_ACCESS_TOKEN=<strava_access_token>
@@ -52,7 +52,7 @@ export STRAVA_ACCESS_TOKEN=<strava_access_token>
 ```python
 from stravaio import StravaIO
 
-# If the token is stored as an environment varible it is not neccessary
+# If the token is stored as an environment variable it is not necessary
 # to pass it as an input parameters
 client = StravaIO(access_token=STRAVA_ACCESS_TOKEN)
 ```

--- a/swagger_client/api/segments_api.py
+++ b/swagger_client/api/segments_api.py
@@ -43,7 +43,7 @@ class SegmentsApi(object):
         >>> result = thread.get()
 
         :param async_req bool
-        :param list[float] bounds: The latitude and longitude for two points describing a rectangular boundary for the search: [southwest corner latitutde, southwest corner longitude, northeast corner latitude, northeast corner longitude] (required)
+        :param list[float] bounds: The latitude and longitude for two points describing a rectangular boundary for the search: [southwest corner latitude, southwest corner longitude, northeast corner latitude, northeast corner longitude] (required)
         :param str activity_type: Desired activity type.
         :param int min_cat: The minimum climbing category.
         :param int max_cat: The maximum climbing category.
@@ -68,7 +68,7 @@ class SegmentsApi(object):
         >>> result = thread.get()
 
         :param async_req bool
-        :param list[float] bounds: The latitude and longitude for two points describing a rectangular boundary for the search: [southwest corner latitutde, southwest corner longitude, northeast corner latitude, northeast corner longitude] (required)
+        :param list[float] bounds: The latitude and longitude for two points describing a rectangular boundary for the search: [southwest corner latitude, southwest corner longitude, northeast corner latitude, northeast corner longitude] (required)
         :param str activity_type: Desired activity type.
         :param int min_cat: The minimum climbing category.
         :param int max_cat: The maximum climbing category.

--- a/swagger_client/models/explorer_segment.py
+++ b/swagger_client/models/explorer_segment.py
@@ -265,7 +265,7 @@ class ExplorerSegment(object):
     def elev_difference(self):
         """Gets the elev_difference of this ExplorerSegment.  # noqa: E501
 
-        The segments's evelation difference, in meters  # noqa: E501
+        The segments's elevation difference, in meters  # noqa: E501
 
         :return: The elev_difference of this ExplorerSegment.  # noqa: E501
         :rtype: float
@@ -276,7 +276,7 @@ class ExplorerSegment(object):
     def elev_difference(self, elev_difference):
         """Sets the elev_difference of this ExplorerSegment.
 
-        The segments's evelation difference, in meters  # noqa: E501
+        The segments's elevation difference, in meters  # noqa: E501
 
         :param elev_difference: The elev_difference of this ExplorerSegment.  # noqa: E501
         :type: float


### PR DESCRIPTION
There are small typos in:
- README.md
- swagger_client/api/segments_api.py
- swagger_client/models/explorer_segment.py

Fixes:
- Should read `latitude` rather than `latitutde`.
- Should read `elevation` rather than `evelation`.
- Should read `variable` rather than `varible`.
- Should read `necessary` rather than `neccessary`.
- Should read `explicitly` rather than `explicitely`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md